### PR TITLE
Fix isFullscreen not updating the navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -147,7 +147,7 @@ export default defineComponent({
       ),
       isFinishedConnecting,
       hasFinishedSetup,
-      isFullscreen: getIsFullscreen(context.root.$store),
+      isFullscreen: computed(() => getIsFullscreen(context.root.$store)),
     }
   },
 })


### PR DESCRIPTION
I don't know if this happens to everyone or if its a known bug, but the navbar/title bar wouldn't go away when I was in fullscreen mode (on Windows 10 2004).

This solves it.

Ps: I'm not a huge Vuex/Vue guy, so this might not be the best way to do it.